### PR TITLE
Changed the keyword (sleep)

### DIFF
--- a/examples/NovaSDS011/NovaSDS011.ino
+++ b/examples/NovaSDS011/NovaSDS011.ino
@@ -70,7 +70,7 @@ void testDataWorkingMode(uint16_t device_id = 0xFFFF)
   Serial.println("Start: testDataWorkingMode with ID " + String(device_id));
 
   // Test Set to Sleep
-  if (!sds011.setWorkingMode(WorkingMode::sleep, device_id))
+  if (!sds011.setWorkingMode(WorkingMode::_sleep, device_id))
   {
     Serial.println("Fail: setting SDS011 Working Mode to sleep.");
     return;
@@ -90,7 +90,7 @@ void testDataWorkingMode(uint16_t device_id = 0xFFFF)
     Serial.println("Fail: getting SDS011 Working Mode.");
     return;
   }
-  if (workingMode == WorkingMode::sleep)
+  if (workingMode == WorkingMode::_sleep)
   {
     Serial.println("Fail: SDS011 Working Mode not as set.");
     return;

--- a/examples/NovaSDS011/NovaSDS011.ino
+++ b/examples/NovaSDS011/NovaSDS011.ino
@@ -85,7 +85,7 @@ void testDataWorkingMode(uint16_t device_id = 0xFFFF)
   }
   delay(400);
   WorkingMode workingMode = sds011.getWorkingMode(device_id);
-  if (workingMode == WorkingMode::mode_work_error)
+  if (workingMode == WorkingMode::mode_error)
   {
     Serial.println("Fail: getting SDS011 Working Mode.");
     return;

--- a/examples/NovaSDS011/NovaSDS011.ino
+++ b/examples/NovaSDS011/NovaSDS011.ino
@@ -70,7 +70,7 @@ void testDataWorkingMode(uint16_t device_id = 0xFFFF)
   Serial.println("Start: testDataWorkingMode with ID " + String(device_id));
 
   // Test Set to Sleep
-  if (!sds011.setWorkingMode(WorkingMode::_sleep, device_id))
+  if (!sds011.setWorkingMode(WorkingMode::mode_sleep, device_id))
   {
     Serial.println("Fail: setting SDS011 Working Mode to sleep.");
     return;
@@ -78,19 +78,19 @@ void testDataWorkingMode(uint16_t device_id = 0xFFFF)
 
   delay(4000); //Hear fan turning off
   //Test Set to Work
-  if (!sds011.setWorkingMode(WorkingMode::work, device_id))
+  if (!sds011.setWorkingMode(WorkingMode::mode_work, device_id))
   {
     Serial.println("Fail: setting SDS011 Working Mode to work.");
     return;
   }
   delay(400);
   WorkingMode workingMode = sds011.getWorkingMode(device_id);
-  if (workingMode == WorkingMode::working_error)
+  if (workingMode == WorkingMode::mode_work_error)
   {
     Serial.println("Fail: getting SDS011 Working Mode.");
     return;
   }
-  if (workingMode == WorkingMode::_sleep)
+  if (workingMode == WorkingMode::mode_sleep)
   {
     Serial.println("Fail: SDS011 Working Mode not as set.");
     return;
@@ -154,7 +154,7 @@ void setup()
   //testDataDutyCycle();
   //testSetDeviceID(0xAAAA);
 
-  if (sds011.setWorkingMode(WorkingMode::work))
+  if (sds011.setWorkingMode(WorkingMode::mode_work))
   {
     Serial.println("SDS011 working mode \"Work\"");
   }

--- a/src/NovaSDS011.cpp
+++ b/src/NovaSDS011.cpp
@@ -463,7 +463,7 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
 #ifndef NO_TRACES
     DebugOut("getWorkingMode - Error read reply timeout");
 #endif
-    return WorkingMode::mode_work_error;
+    return WorkingMode::mode_error;
   }
 
   WORKING_MODE_REPLY[3] = WORKING_MODE_CMD[3]; //Get reporting mode
@@ -488,7 +488,7 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
       DebugOut("getWorkingMode - Error on byte " + String(i) + " Received byte=" + String(reply[i]) +
                " Expected byte=" + String(WORKING_MODE_REPLY[i]));
 #endif
-      return WorkingMode::mode_work_error;
+      return WorkingMode::mode_error;
     }
   }
 
@@ -502,7 +502,7 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
   }
   else
   {
-    return WorkingMode::mode_work_error;
+    return WorkingMode::mode_error;
   }
 }
 
@@ -590,7 +590,7 @@ uint8_t NovaSDS011::getDutyCycle(uint16_t device_id)
 #ifndef NO_TRACES
     DebugOut("getDutyCycle - Error read reply timeout");
 #endif
-    return WorkingMode::mode_work_error;
+    return WorkingMode::mode_error;
   }
 
   DUTY_CYCLE_REPLY[3] = DUTY_CYCLE_CMD[3]; //Get reporting mode
@@ -615,7 +615,7 @@ uint8_t NovaSDS011::getDutyCycle(uint16_t device_id)
       DebugOut("getDutyCycle - Error on byte " + String(i) + " Received byte=" + String(reply[i]) +
                " Expected byte=" + String(DUTY_CYCLE_REPLY[i]));
 #endif
-      return WorkingMode::mode_work_error;
+      return WorkingMode::mode_error;
     }
   }
 

--- a/src/NovaSDS011.cpp
+++ b/src/NovaSDS011.cpp
@@ -404,7 +404,7 @@ bool NovaSDS011::setWorkingMode(WorkingMode mode, uint16_t device_id)
 
   timeout = readReply(reply);
 
-  if ((mode == WorkingMode::sleep) && (timeout))
+  if ((mode == WorkingMode::_sleep) && (timeout))
   {
 #ifndef NO_TRACES
     DebugOut("setWorkingMode - Read timeout");
@@ -492,9 +492,9 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
     }
   }
 
-  if (reply[4] == WorkingMode::sleep)
+  if (reply[4] == WorkingMode::_sleep)
   {
-    return WorkingMode::sleep;
+    return WorkingMode::_sleep;
   }
   else if (reply[4] == WorkingMode::work)
   {

--- a/src/NovaSDS011.cpp
+++ b/src/NovaSDS011.cpp
@@ -404,7 +404,7 @@ bool NovaSDS011::setWorkingMode(WorkingMode mode, uint16_t device_id)
 
   timeout = readReply(reply);
 
-  if ((mode == WorkingMode::_sleep) && (timeout))
+  if ((mode == WorkingMode::mode_sleep) && (timeout))
   {
 #ifndef NO_TRACES
     DebugOut("setWorkingMode - Read timeout");
@@ -463,7 +463,7 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
 #ifndef NO_TRACES
     DebugOut("getWorkingMode - Error read reply timeout");
 #endif
-    return WorkingMode::working_error;
+    return WorkingMode::mode_work_error;
   }
 
   WORKING_MODE_REPLY[3] = WORKING_MODE_CMD[3]; //Get reporting mode
@@ -488,21 +488,21 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
       DebugOut("getWorkingMode - Error on byte " + String(i) + " Received byte=" + String(reply[i]) +
                " Expected byte=" + String(WORKING_MODE_REPLY[i]));
 #endif
-      return WorkingMode::working_error;
+      return WorkingMode::mode_work_error;
     }
   }
 
-  if (reply[4] == WorkingMode::_sleep)
+  if (reply[4] == WorkingMode::mode_sleep)
   {
-    return WorkingMode::_sleep;
+    return WorkingMode::mode_sleep;
   }
   else if (reply[4] == WorkingMode::work)
   {
-    return WorkingMode::work;
+    return WorkingMode::mode_work;
   }
   else
   {
-    return WorkingMode::working_error;
+    return WorkingMode::mode_work_error;
   }
 }
 
@@ -590,7 +590,7 @@ uint8_t NovaSDS011::getDutyCycle(uint16_t device_id)
 #ifndef NO_TRACES
     DebugOut("getDutyCycle - Error read reply timeout");
 #endif
-    return WorkingMode::working_error;
+    return WorkingMode::mode_work_error;
   }
 
   DUTY_CYCLE_REPLY[3] = DUTY_CYCLE_CMD[3]; //Get reporting mode
@@ -615,7 +615,7 @@ uint8_t NovaSDS011::getDutyCycle(uint16_t device_id)
       DebugOut("getDutyCycle - Error on byte " + String(i) + " Received byte=" + String(reply[i]) +
                " Expected byte=" + String(DUTY_CYCLE_REPLY[i]));
 #endif
-      return WorkingMode::working_error;
+      return WorkingMode::mode_work_error;
     }
   }
 

--- a/src/NovaSDS011.h
+++ b/src/NovaSDS011.h
@@ -41,7 +41,7 @@ enum QuerryError
 
 enum WorkingMode
 {
-	sleep = 0,
+	_sleep = 0,
 	work = 1,
 	working_error = 0xFF
 };

--- a/src/NovaSDS011.h
+++ b/src/NovaSDS011.h
@@ -43,7 +43,7 @@ enum WorkingMode
 {
 	mode_sleep = 0,
 	mode_work = 1,
-	mode_work_error = 0xFF
+	mode_error = 0xFF
 };
 
 struct SDS011Version

--- a/src/NovaSDS011.h
+++ b/src/NovaSDS011.h
@@ -41,9 +41,9 @@ enum QuerryError
 
 enum WorkingMode
 {
-	_sleep = 0,
-	work = 1,
-	working_error = 0xFF
+	mode_sleep = 0,
+	mode_work = 1,
+	mode_work_error = 0xFF
 };
 
 struct SDS011Version


### PR DESCRIPTION
I was implementing the library in my project on ESP32 and I came across this problem. The library was not compiling due to the conflict with the keyword (sleep).

I have made the fix. Hope it will help others as well.

> Imp Note: To use this library with ESP32, you will need [EspSoftwareSerial](https://github.com/plerup/espsoftwareserial.git) library as well.

