### PR TITLE
Add ESP32 support based on HardwareSerial

### DIFF
--- a/src/NovaSDS011.cpp
+++ b/src/NovaSDS011.cpp
@@ -12,6 +12,12 @@
 #include "NovaSDS011.h"
 #include "Commands.h"
 
+#ifdef ESP32
+#include <HardwareSerial.h>
+#else
+#include <SoftwareSerial.h>
+#endif
+
 #define MIN_QUERY_INTERVAL 3000
 
 // --------------------------------------------------------
@@ -114,6 +120,7 @@ bool NovaSDS011::readReply(ReplyType &reply)
   return timeout;
 }
 
+#ifndef ESP32
 // --------------------------------------------------------
 // NovaSDS011:begin
 // --------------------------------------------------------
@@ -128,6 +135,21 @@ void NovaSDS011::begin(uint8_t pin_rx, uint8_t pin_tx, uint16_t wait_write_read)
 
   clearSerial();
 }
+
+#else
+// --------------------------------------------------------
+// NovaSDS011:begin
+// --------------------------------------------------------
+void NovaSDS011::begin(HardwareSerial * serial, uint8_t pin_rx, uint8_t pin_tx, uint16_t wait_write_read) {
+    _waitWriteRead = wait_write_read;
+
+  serial->begin(9600, SERIAL_8N1, pin_rx, pin_tx);  
+  
+  _sdsSerial = serial;
+
+  clearSerial();
+}
+#endif
 
 // --------------------------------------------------------
 // NovaSDS011:setDataReportingMode
@@ -404,7 +426,7 @@ bool NovaSDS011::setWorkingMode(WorkingMode mode, uint16_t device_id)
 
   timeout = readReply(reply);
 
-  if ((mode == WorkingMode::sleep) && (timeout))
+  if ((mode == WorkingMode::NOVASDS011_SLEEPMODE) && (timeout))
   {
 #ifndef NO_TRACES
     DebugOut("setWorkingMode - Read timeout");
@@ -492,9 +514,9 @@ WorkingMode NovaSDS011::getWorkingMode(uint16_t device_id)
     }
   }
 
-  if (reply[4] == WorkingMode::sleep)
+  if (reply[4] == WorkingMode::NOVASDS011_SLEEPMODE)
   {
-    return WorkingMode::sleep;
+    return WorkingMode::NOVASDS011_SLEEPMODE;
   }
   else if (reply[4] == WorkingMode::work)
   {

--- a/src/NovaSDS011.h
+++ b/src/NovaSDS011.h
@@ -17,9 +17,12 @@
 #include "WProgram.h"
 #endif
 
-#include <SoftwareSerial.h>
-
 #define NO_TRACES 
+
+#ifdef ESP32
+// ESP32 does not support softwareserial.
+#include<HardwareSerial.h>
+#endif
 
 typedef uint8_t CommandType[19];
 typedef uint8_t ReplyType[10];
@@ -39,9 +42,18 @@ enum QuerryError
 	call_to_often = 3
 };
 
+
+#ifdef ESP32
+// Compiler will not allow redaclaration of symbol sleep for ESP32 arduino.
+// By defining a symbol library is kept backwards compatible with previous versions
+#define NOVASDS011_SLEEPMODE sleepMode
+#else
+#define NOVASDS011_SLEEPMODE sleep
+#endif
+
 enum WorkingMode
 {
-	sleep = 0,
+	NOVASDS011_SLEEPMODE = 0,
 	work = 1,
 	working_error = 0xFF
 };
@@ -63,6 +75,7 @@ public:
 		*/
 	NovaSDS011();
 
+#ifndef ESP32
 	/**
 		* Initialize communication via serial bus.
 		* @param pin_rx 
@@ -70,6 +83,17 @@ public:
 		* @param wait_write_read Max time in ms to wait for response after sending command to sensor.
 		*/
 	void begin(uint8_t pin_rx, uint8_t pin_tx, uint16_t wait_write_read = 500);
+
+#else
+	/**
+		* Initialize communication via serial bus.
+		* @param serial The hardware serial to use
+		* @param pin_rx 
+		* @param pin_tx 
+		* @param wait_write_read Max time in ms to wait for response after sending command to sensor.
+		*/
+	void begin(HardwareSerial * serial, uint8_t pin_rx, uint8_t pin_tx, uint16_t wait_write_read = 500);
+#endif
 
 	/**
 		* Set report mode to specific device or to all devices connected to bus.


### PR DESCRIPTION
Hi Silvan,
I have added esp32 support to your libray.
1. The esp32 does not support SoftwareSerial, so I added HardwareSerial instead
2. The esp32 compiler complains when redeclaring "sleep" (as in the modes enum). I have therefore added a backwards compatible define.

Would you be willing to integrate this?

Best regards
Jan